### PR TITLE
Extended to support storing of runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,39 @@
 
 Wrapper around [Flipper](https://github.com/jnunemaker/flipper) whose job is to toggle applications features. And is using Redis as preferred persistence adapter.
 
-## Add to your project
+## Installation
 
-In gemfile add:
+Add this line to your application's Gemfile:
 
     gem "feature_flag", git: "https://github.com/betterdoc-org/gem-feature-flag"
 
-install:
+And then execute:
 
     bundle install
 
+## Usage
 
-On application start:
+Add this to your application
 
     require 'feature_flag'
-
-    # set persistence adapter
-    # if test env:
-    adapter = FeatureFlag.memory_adapter
-    # else use redis and provide redis url:
-    adapter = FeatureFlag.redis_adapter(Redis.new(url: ENV.fetch('FLIPPER_REDIS_URL')))
 
     # set feature key prefix
     prefix = ENV.fetch('FEATURE_FLAGS_PREFIX")
 
-    # init setup
-    FeatureFlag.configure(adapter: adapter, prefix: prefix)
+    # provide prexix and adapter options
+    FeatureFlag.configure(prefix: prefix, adapter: :redis, url: ENV.fetch("FEATURE_FLAGS_REDIS_URL"))
 
-Use in your application:
+If you are on Rails you can put something like this in `config/initializers/feature_flags.rb`:
+
+    if Rails.env.test?
+      FeatureFlag.configure(prefix: "some-prefix-", adapter: :memory)
+    else
+      FeatureFlag.configure(prefix: "some-prefix-", adapter: :redis, url: ENV.fetch("FEATURE_FLAGS_REDIS_URL"))
+    end
+
+### Usage for Feature flags
+
+You can now toggle feature flags in your app super easily:
 
     FeatureFlag.enable('some-feature')
 
@@ -39,8 +44,42 @@ Use in your application:
 
     FeatureFlag.disabled?('some-feature')
 
-Development
+### Usage for Runtime configuration
+
+You can store configuration that can be changed at runtime:
+
+    FeatureFlag.config.set("some-config", "foo")
+    FeatureFlag.config.set("some-other-config", "bar")
+
+To get the stored config:
+
+    FeatureFlag.config.get("some-config") # => "foo"
+    FeatureFlag.config.get("some-other-config") # => "bar"
+
+
+To get all config as a hash:
+
+    FeatureFlag.config.to_h
+
+Keep in mind that all keys and values are stored as Strings and if you need to store complex config you should serialize/desirialize it:
+
+    FeatureFlag.config.set("days-to-keep-backup", 14)
+    FeatureFlag.config.get("days-to-keep-backup") # => "14"
+    options = { foo: :bar }
+    FeatureFlag.config.set("multiple-config-options", YAML.dump(options))
+    str = FeatureFlag.config.get("multiple-config-options") # => "---\n:foo: :bar\n"
+    YAML.load(str) # => { foo: :bar }
+
+## Development
+
+Install dependencies:
 
     bundle install
 
-    rake spec
+Run tests:
+
+    rake
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/feature_flag/adapters/memory.rb
+++ b/lib/feature_flag/adapters/memory.rb
@@ -1,0 +1,34 @@
+require "flipper/adapters/memory"
+
+module FeatureFlag
+  module Adapters
+    class Memory < Flipper::Adapters::Memory
+      def initialize(prefix:, source: nil)
+        @prefix = prefix.to_s
+        super(source)
+      end
+
+      def config
+        @source[config_key] ||= {}
+      end
+
+      def config_clear
+        @source[config_key] = {}
+      end
+
+      def config_get(key)
+        config[key.to_s]
+      end
+
+      def config_set(key, value)
+        config[key.to_s] = value.to_s
+      end
+
+      private
+
+      def config_key
+        @config_key ||= [@prefix, "config"].join
+      end
+    end
+  end
+end

--- a/lib/feature_flag/adapters/redis.rb
+++ b/lib/feature_flag/adapters/redis.rb
@@ -1,0 +1,36 @@
+require "flipper/adapters/redis"
+
+module FeatureFlag
+  module Adapters
+    class Redis < Flipper::Adapters::Redis
+      def initialize(options = {})
+        @prefix = options.delete(:prefix).to_s.strip
+        raise(ArgumentError, "prefix can't be blank") if @prefix.empty?
+
+        super(::Redis.new(options))
+      end
+
+      def config
+        @client.hgetall(config_key)
+      end
+
+      def config_clear
+        @client.del(config_key)
+      end
+
+      def config_get(key)
+        @client.hget(config_key, key.to_s)
+      end
+
+      def config_set(key, value)
+        @client.hset(config_key, key.to_s, value.to_s)
+      end
+
+      private
+
+      def config_key
+        @config_key ||= [@prefix, "config"].join
+      end
+    end
+  end
+end

--- a/lib/feature_flag/config.rb
+++ b/lib/feature_flag/config.rb
@@ -1,0 +1,25 @@
+module FeatureFlag
+  class Config
+    def clear
+      adapter.config_clear
+    end
+
+    def get(key)
+      adapter.config_get(key)
+    end
+
+    def set(key, value)
+      adapter.config_set(key, value)
+    end
+
+    def to_h
+      adapter.config
+    end
+
+    private
+
+    def adapter
+      FeatureFlag.flipper.adapter.adapter
+    end
+  end
+end

--- a/spec/feature_flag/adapters/memory_spec.rb
+++ b/spec/feature_flag/adapters/memory_spec.rb
@@ -1,0 +1,19 @@
+require "support/shared_examples_for_adapters"
+
+RSpec.describe FeatureFlag::Adapters::Memory do
+  subject(:adapter) { described_class.new(prefix: "some-prefix-") }
+
+  it_behaves_like "a feature flag adapter"
+
+  it "raises error if prefix is missing on init" do
+    expect { described_class.new }.to raise_error ArgumentError
+  end
+
+  it "saves to config key prefixed with provided prefix" do
+    source = {}
+    adapter = described_class.new(prefix: "some-prefix-", source: source)
+
+    expect(source).to be_empty
+    expect { adapter.config_set("foo", "bar") }.to change { source.keys }.to ["some-prefix-config"]
+  end
+end

--- a/spec/feature_flag/adapters/redis_spec.rb
+++ b/spec/feature_flag/adapters/redis_spec.rb
@@ -1,0 +1,26 @@
+require "support/shared_examples_for_adapters"
+
+RSpec.describe FeatureFlag::Adapters::Redis do
+  let(:redis_url) { ENV["REDIS_URL"] || "redis://127.0.0.1:6379/0" }
+  subject(:adapter) { described_class.new( prefix: "some-prefix-", url: redis_url) }
+
+  it_behaves_like "a feature flag adapter"
+
+  it "raises error if prefix is missing on init" do
+    expect { described_class.new(url: redis_url) }.to raise_error ArgumentError
+    expect { described_class.new(prefix: nil, url: redis_url) }.to raise_error ArgumentError
+    expect { described_class.new(prefix: "", url: redis_url) }.to raise_error ArgumentError
+    expect { described_class.new(prefix: " ", url: redis_url) }.to raise_error ArgumentError
+  end
+
+  it "saves to config key prefixed with provided prefix" do
+    adapter.config_set("foo", "bar")
+    client = adapter.instance_variable_get(:@client)
+    expect(client).to receive(:hgetall).with("some-prefix-config")
+    adapter.config
+    expect(client).to receive(:hset).with("some-prefix-config", "foo", "bar")
+    adapter.config_set("foo", "bar")
+    expect(client).to receive(:hget).with("some-prefix-config", "foo")
+    adapter.config_get("foo")
+  end
+end

--- a/spec/feature_flag/config_spec.rb
+++ b/spec/feature_flag/config_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe FeatureFlag::Config do
+  subject(:config) { FeatureFlag::Config.new }
+
+  before(:each) do
+    FeatureFlag.configure(adapter: :memory, prefix: 'some-prefix-')
+    FeatureFlag.config.clear
+  end
+
+  describe "#set" do
+    it "saves the provided value as a config with the provided key" do
+      config.set("foo", "bar")
+      expect(config.get("foo")).to eq("bar")
+    end
+
+    it "saves the provided value always as a string" do
+      config.set("foo", :bar)
+      config.set("count", 123)
+      config.set("array", [1, 2, 3])
+
+      expect(config.get("foo")).to eq("bar")
+      expect(config.get("count")).to eq("123")
+      expect(config.get("array")).to eq("[1, 2, 3]")
+    end
+
+    it "saves the provided key always as a string" do
+      config.set(:foo, :bar)
+      config.set(1234, "count")
+      config.set([1, 2, 3], "array")
+
+      expect(config.to_h.keys).to match_array ["foo", "1234", "[1, 2, 3]"]
+    end
+  end
+
+  describe "#get" do
+    it "gest the value for the saved key" do
+      config.set("foo", "bar")
+      expect(config.get("foo")).to eq "bar"
+    end
+
+    it "returns nil if value is not yet saved" do
+      expect(config.get("foo")).to eq nil
+    end
+
+    it "always gets by key as a string" do
+      config.set(:fiz, "baz")
+      config.set(123, "count")
+      config.set([1, 2, 3], "array")
+
+      expect(config.get(:fiz)).to eq "baz"
+      expect(config.get("fiz")).to eq "baz"
+      expect(config.get(123)).to eq "count"
+      expect(config.get("123")).to eq "count"
+      expect(config.get([1, 2, 3])).to eq "array"
+      expect(config.get("[1, 2, 3]")).to eq "array"
+    end
+  end
+
+  describe "#to_h" do
+    it "it is empty hash by default" do
+      expect(config.to_h).to eq({})
+    end
+
+    it "returns hash with all configs" do
+      config.set(:foo, :bar)
+      config.set(:fiz, :baz)
+      expect(config.to_h).to eq({ "foo" => "bar", "fiz" => "baz" })
+    end
+  end
+end

--- a/spec/feature_flag_spec.rb
+++ b/spec/feature_flag_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe FeatureFlag do
   before(:each) do
-    FeatureFlag.configure(adapter: FeatureFlag.memory_adapter, prefix: 'some-prefix-')
+    FeatureFlag.configure(adapter: :memory, prefix: 'some-prefix-')
   end
 
   it "has a version number" do
@@ -51,8 +51,14 @@ RSpec.describe FeatureFlag do
 
   it "raise error if prefix or adapter are not valid" do
     [nil, "     ", ""].each do |prefix|
-      expect { FeatureFlag.configure(adapter: FeatureFlag.memory_adapter, prefix: prefix) }.to raise_error ArgumentError
+      expect { FeatureFlag.configure(adapter: :memory, prefix: prefix) }.to raise_error ArgumentError
     end
     expect { FeatureFlag.configure(prefix: 'some-prefix-') }.to raise_error ArgumentError
+  end
+
+  describe "#config" do
+    it "is an instance of FeatureFlag::Config class" do
+      expect(FeatureFlag.config.class).to eq(FeatureFlag::Config)
+    end
   end
 end

--- a/spec/support/shared_examples_for_adapters.rb
+++ b/spec/support/shared_examples_for_adapters.rb
@@ -1,0 +1,73 @@
+RSpec.shared_examples "a feature flag adapter" do
+  before do
+    adapter.config_clear
+  end
+
+  describe "#config" do
+    it "it is empty hash by default" do
+      expect(adapter.config).to eq({})
+    end
+
+    it "returns hash with all configs" do
+      adapter.config_set(:foo, :bar)
+      adapter.config_set(:fiz, :baz)
+      expect(adapter.config).to eq({ "foo" => "bar", "fiz" => "baz" })
+    end
+  end
+
+  describe "#config_clear" do
+    it "deletes everything from config" do
+      adapter.config_set(:foo, :bar)
+      expect { adapter.config_clear }.to change { adapter.config }.from({ "foo" => "bar" }).to({})
+    end
+  end
+
+  describe "#config_get" do
+    it "gets the value for the key" do
+      adapter.config_set("foo", "bar")
+      expect(adapter.config_get("foo")).to eq "bar"
+    end
+
+    it "returns nil if nothing is yet saved" do
+      expect(adapter.config_get("foo")).to eq nil
+    end
+
+    it "always gets by key as a string" do
+      adapter.config_set(:fiz, "baz")
+      adapter.config_set(123, "count")
+      adapter.config_set([1, 2, 3], "array")
+
+      expect(adapter.config_get(:fiz)).to eq "baz"
+      expect(adapter.config_get("fiz")).to eq "baz"
+      expect(adapter.config_get(123)).to eq "count"
+      expect(adapter.config_get("123")).to eq "count"
+      expect(adapter.config_get([1, 2, 3])).to eq "array"
+      expect(adapter.config_get("[1, 2, 3]")).to eq "array"
+    end
+  end
+
+  describe "#set" do
+    it "saves the provided value as a config with the provided key" do
+      adapter.config_set("foo", "bar")
+      expect(adapter.config_get("foo")).to eq("bar")
+    end
+
+    it "saves the provided value always as a string" do
+      adapter.config_set("foo", :bar)
+      adapter.config_set("count", 123)
+      adapter.config_set("array", [1, 2, 3])
+
+      expect(adapter.config_get("foo")).to eq("bar")
+      expect(adapter.config_get("count")).to eq("123")
+      expect(adapter.config_get("array")).to eq("[1, 2, 3]")
+    end
+
+    it "saves the provided key always as a string" do
+      adapter.config_set(:foo, :bar)
+      adapter.config_set(1234, "count")
+      adapter.config_set([1, 2, 3], "array")
+
+      expect(adapter.config.keys).to match_array ["foo", "1234", "[1, 2, 3]"]
+    end
+  end
+end


### PR DESCRIPTION
This adds option to store configuration that can be changed at runtime. It will use same prefix that is used for feature flags (your config will be saved in Redis as a hash under `your-prefix-config` key). 

Original gem and Flipper just save keys to Redis set so I needed to extend standard adapters a bit to be able to set/get config values.

Usage examples:

```ruby
FeatureFlag.config.set("days-to-keep-backup", 14)
FeatureFlag.config.get("days-to-keep-backup") # => "14"
FeatureFlag.config.to_h # => { "days-to-keep-backup" => "14" }
```

Note that you can only save string values so you need to serialise/desirialize data if you want. to save something more complex. See Readme for more info.